### PR TITLE
guard against failed purge in startup script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 
 set -x
 
+# the purge can fail when /etc/ssh is a mounted volume in k8s
+# so try it to delete what we can, but don't stop the script if it fails
+set +e
 # reinstall openssh if no config provided
 test -e /etc/ssh/sshd_config || { dpkg --purge openssh-server; apt-get install -y openssh-server; }
+set -e
 
 # home directory won't exsist on first boot since the user was created during docker file build
 # before the volume is mounted


### PR DESCRIPTION
Had a problem with containers failing to start on k8s because the purge of openssh-server could not delete `/etc/ssh` because it was a mounted volume. It's not really a problem if it can't delete it, I don't think, since the install on the next line seems to successfully replace any keys and configs. However if this is a security issue we might need to find another way?

Signed-off-by: Trevor Whitney <trevorjwhitney@gmail.com>